### PR TITLE
refactor: use different map types

### DIFF
--- a/cmd/sshman/main.go
+++ b/cmd/sshman/main.go
@@ -16,7 +16,7 @@ import (
 var appInfo = cli.AppInfo{
 	Name:        "sshman",
 	Description: "Easy ssh connection management.",
-	Version:     "1.0.3",
+	Version:     "1.0.5",
 	Author:      "@mikeunge",
 	Github:      "https://github.com/mikeunge/sshman",
 }
@@ -47,14 +47,11 @@ func main() {
 	}
 
 	if _, ok := cmds["connect"]; ok {
-		var pId int64
-
-		profileId := cmds["connect"]
-		if pId, ok = profileId.(int64); !ok {
-			handleErrorAndCloseGracefully(err, 1, db)
+		var profileId int64
+		if profileId = cmds["connect"]; profileId <= 0 {
+			handleErrorAndCloseGracefully(fmt.Errorf("Profile ID cannot be 0 or less."), -1, db)
 		}
-
-		err := profileService.ConnectToSHHWithProfile(pId)
+		err := profileService.ConnectToSHHWithProfile(profileId)
 		handleErrorAndCloseGracefully(err, 1, db)
 		os.Exit(0)
 	}
@@ -81,10 +78,7 @@ func main() {
 		handleErrorAndCloseGracefully(err, 1, db)
 		profile.Host = host
 
-		var authType database.SSHProfileAuthType
-		if authType, ok = cmds["type"].(database.SSHProfileAuthType); !ok {
-			handleErrorAndCloseGracefully(err, 1, db)
-		}
+		authType := database.SSHProfileAuthType(cmds["type"])
 		profile.AuthType = authType
 
 		var auth string

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,11 +18,10 @@ type AppInfo struct {
 	Github      string
 }
 
-// FIXME: not best practice to use an interface because of missing types - find a better way to move data across the packages.
-type Commands map[string]interface{}
+type Commands map[string]int64
 
 func Cli(app *AppInfo) (Commands, error) {
-	var cmds = make(map[string]interface{})
+	var cmds = make(map[string]int64)
 
 	parser := argparse.NewParser(app.Name, app.Description)
 	argVersion := parser.Flag("v", "version", &argparse.Options{Required: false, Help: "Prints the version."})
@@ -49,24 +48,24 @@ func Cli(app *AppInfo) (Commands, error) {
 	}
 
 	if *argList {
-		cmds["list"] = ""
+		cmds["list"] = 0
 		return cmds, nil
 	}
 
 	if *argConnect > 0 {
-		cmds["connect"] = fmt.Sprintf("%d", *argConnect)
+		cmds["connect"] = int64(*argConnect)
 		return cmds, nil
 	}
 
 	if len(*argNew) > 0 {
 		if *argNew == "password" {
-			cmds["type"] = database.AuthTypePassword
+			cmds["type"] = int64(database.AuthTypePassword)
 		} else if *argNew == "keyfile" {
-			cmds["type"] = database.AuthTypePrivateKey
+			cmds["type"] = int64(database.AuthTypePrivateKey)
 		} else {
 			return cmds, fmt.Errorf("Could not parse: %s\n", *argNew)
 		}
-		cmds["new"] = ""
+		cmds["new"] = 0
 		return cmds, nil
 	}
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -13,7 +13,7 @@ type DB struct {
 }
 
 // Create an enum (SSHProfileType) because go doesn't provide it by default...
-type SSHProfileAuthType int
+type SSHProfileAuthType int64
 
 // SSH (enum-) types
 const (


### PR DESCRIPTION
Switch cli map from interface to int64 for better/easier handling.
map[string]interface{} -> map[string]int64