### PR TITLE
feat: add encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Available Options:
 
   -c  --connect           Connect to a server with profile.
   -n  --new               Create a new SSH profile.
+      --encrypt           Encrypt the password / key file for more security. (only for new profiles)
   -u  --update            Update an SSH profile.
   -d  --delete            Delete SSH profiles.
   -e  --export            Export profiles (for eg. sharing). (WIP)
@@ -42,4 +43,5 @@ Available Options:
 ## Special thanks
 
 - [@atotto](https://gist.github.com/atotto/ba19155295d95c8d75881e145c751372) for this genius gist
+- [@donvito](https://gist.github.com/donvito/efb2c643b724cf6ff453da84985281f8) for helping with my lack of knowledge regarding encryption
 

--- a/cmd/sshman/main.go
+++ b/cmd/sshman/main.go
@@ -22,7 +22,7 @@ func main() {
 	var app = cli.App{
 		Name:        "sshman",
 		Description: "SSH connection management tool.",
-		Version:     "1.1.1",
+		Version:     "1.1.2",
 		Author:      "@mikeunge",
 		Github:      "https://github.com/mikeunge/sshman",
 	}
@@ -56,7 +56,11 @@ func main() {
 		handleErrorAndCloseGracefully(err, 1, db)
 		break
 	case cli.CommandNew:
-		err := profileService.NewProfile()
+		enc := false
+		if app.Args.AdditionalArgument == "encrypt" {
+			enc = true
+		}
+		err := profileService.NewProfile(enc)
 		handleErrorAndCloseGracefully(err, 1, db)
 		break
 	case cli.CommandUpdate:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -20,6 +20,7 @@ const (
 	CommandExport  Command = 5
 )
 
+// TODO: change the additional arguments - maybe parse like key value pairs
 type Arguments struct {
 	SelectedCommand    Command
 	AdditionalArgument string
@@ -42,6 +43,7 @@ func (app *App) New() error {
 
 	argConnect := parser.Flag("c", "connect", &argparse.Options{Required: false, Help: "Connect to a server with profile."})
 	argNew := parser.Flag("n", "new", &argparse.Options{Required: false, Help: "Create a new SSH profile."})
+	argEncrypt := parser.Flag("", "encrypt", &argparse.Options{Required: false, Help: "Encrypt the password/private key."})
 	argUpdate := parser.Flag("u", "update", &argparse.Options{Required: false, Help: "Update an SSH profile."})
 	argDelete := parser.Flag("d", "delete", &argparse.Options{Required: false, Help: "Delete SSH profiles."})
 	argExport := parser.Flag("e", "export", &argparse.Options{Required: false, Help: "Export profiles (for eg. sharing)."})
@@ -99,6 +101,10 @@ func (app *App) New() error {
 	}
 
 	if *argNew {
+		// Encryption can only be set when creating a new key
+		if *argEncrypt {
+			app.Args.AdditionalArgument = "encrypt"
+		}
 		app.Args.SelectedCommand = CommandNew
 		return nil
 	}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -51,6 +51,7 @@ type SSHProfile struct {
 	Password   string
 	PrivateKey []byte
 	AuthType   SSHProfileAuthType
+	Encrypted  bool
 	CTime      time.Time
 	MTime      time.Time
 }

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (d *DB) CreateSSHProfile(profile SSHProfile) (int64, error) {
-	res, err := d.db.Exec("INSERT INTO SSH_Profile (alias, host, user, password, privateKey, type) VALUES(?, ?, ?, ?, ?, ?);", profile.Alias, profile.Host, profile.User, profile.Password, profile.PrivateKey, profile.AuthType)
+	res, err := d.db.Exec("INSERT INTO SSH_Profile (alias, host, user, password, privateKey, type, encrypted) VALUES(?, ?, ?, ?, ?, ?, ?);", profile.Alias, profile.Host, profile.User, profile.Password, profile.PrivateKey, profile.AuthType, profile.Encrypted)
 	if err != nil {
 		return 0, err
 	}
@@ -23,7 +23,7 @@ func (d *DB) GetSSHProfileById(id int64) (SSHProfile, error) {
 	var profile SSHProfile
 
 	row := d.db.QueryRow("SELECT * FROM SSH_Profile WHERE id=?;", id)
-	if err := row.Scan(&profile.Id, &profile.Alias, &profile.Host, &profile.User, &profile.Password, &profile.PrivateKey, &profile.AuthType, profile.CTime, &profile.MTime); err == sql.ErrNoRows {
+	if err := row.Scan(&profile.Id, &profile.Alias, &profile.Host, &profile.User, &profile.Password, &profile.PrivateKey, &profile.AuthType, &profile.Encrypted, profile.CTime, &profile.MTime); err == sql.ErrNoRows {
 		return SSHProfile{}, err
 	}
 	return profile, nil
@@ -33,7 +33,7 @@ func (d *DB) GetSSHProfileByAlias(alias string) (SSHProfile, error) {
 	var profile SSHProfile
 
 	row := d.db.QueryRow("SELECT * FROM SSH_Profile WHERE alias=?;", alias)
-	if err := row.Scan(&profile.Id, &profile.Alias, &profile.Host, &profile.User, &profile.Password, &profile.PrivateKey, &profile.AuthType, profile.CTime, &profile.MTime); err == sql.ErrNoRows {
+	if err := row.Scan(&profile.Id, &profile.Alias, &profile.Host, &profile.User, &profile.Password, &profile.PrivateKey, &profile.AuthType, &profile.Encrypted, profile.CTime, &profile.MTime); err == sql.ErrNoRows {
 		return SSHProfile{}, err
 	}
 	return profile, nil
@@ -59,7 +59,7 @@ func (d *DB) GetSSHProfilesById(ids []int64) ([]SSHProfile, error) {
 
 	for rows.Next() {
 		var profile SSHProfile
-		if err = rows.Scan(&profile.Id, &profile.Alias, &profile.Host, &profile.User, &profile.Password, &profile.PrivateKey, &profile.AuthType, &profile.CTime, &profile.MTime); err == sql.ErrNoRows {
+		if err = rows.Scan(&profile.Id, &profile.Alias, &profile.Host, &profile.User, &profile.Password, &profile.PrivateKey, &profile.AuthType, &profile.Encrypted, &profile.CTime, &profile.MTime); err == sql.ErrNoRows {
 			return profiles, err
 		}
 		profiles = append(profiles, profile)
@@ -78,7 +78,7 @@ func (d *DB) GetAllSSHProfiles() ([]SSHProfile, error) {
 
 	for rows.Next() {
 		var profile SSHProfile
-		if err = rows.Scan(&profile.Id, &profile.Alias, &profile.Host, &profile.User, &profile.Password, &profile.PrivateKey, &profile.AuthType, &profile.CTime, &profile.MTime); err == sql.ErrNoRows {
+		if err = rows.Scan(&profile.Id, &profile.Alias, &profile.Host, &profile.User, &profile.Password, &profile.PrivateKey, &profile.AuthType, &profile.Encrypted, &profile.CTime, &profile.MTime); err == sql.ErrNoRows {
 			return profiles, err
 		}
 		profiles = append(profiles, profile)

--- a/internal/database/setup.go
+++ b/internal/database/setup.go
@@ -15,7 +15,8 @@ const (
     user TEXT NOT NULL,
     password TEXT,
     privateKey BLOB,
-    type INTEGER NOT NULL,
+    type TINYINT NOT NULL,
+    encrypted BOOLEAN NOT NULL DEFAULT 0,
     ctime DATETIME DEFAULT CURRENT_TIMESTAMP,
     mtime DATETIME DEFAULT CURRENT_TIMESTAMP
   );`

--- a/internal/profiles/select.go
+++ b/internal/profiles/select.go
@@ -89,10 +89,14 @@ func prettyPrintProfiles(profiles []database.SSHProfile) {
 	var data [][]string
 	var dFormat = "02.01.2006"
 
-	data = append(data, []string{"Id", "Alias", "User", "Host/IP", "Authentication", "Created At"}) // define the table header
+	data = append(data, []string{"Id", "Alias", "User", "Host/IP", "Authentication", "Encrypted", "Created At"}) // define the table header
 	for _, profile := range profiles {
+		encrypted := "-"
 		authType := database.GetNameFromAuthType(profile.AuthType)
-		data = append(data, []string{fmt.Sprintf("%d", profile.Id), profile.Alias, profile.User, profile.Host, authType, profile.CTime.Format(dFormat)})
+		if profile.Encrypted {
+			encrypted = "+"
+		}
+		data = append(data, []string{fmt.Sprintf("%d", profile.Id), profile.Alias, profile.User, profile.Host, authType, encrypted, profile.CTime.Format(dFormat)})
 	}
 	pterm.DefaultTable.
 		WithHasHeader().

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -1,8 +1,13 @@
 package helpers
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"io/fs"
 	"net"
 	"os"
@@ -147,4 +152,65 @@ func IsValidUrl(uri string) bool {
 
 	re := regexp.MustCompile(`^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/|\/|\/\/)?[A-z0-9_-]*?[:]?[A-z0-9_-]*?[@]?[A-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$`)
 	return re.MatchString(uri)
+}
+
+func EncryptString(data string, encKey string) (string, error) {
+	//Since the key is in string, we need to convert decode it to bytes
+	key, _ := hex.DecodeString(encKey)
+	plaintext := []byte(data)
+
+	//Create a new Cipher Block from the key
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+
+	//Create a new GCM - https://en.wikipedia.org/wiki/Galois/Counter_Mode
+	//https://golang.org/pkg/crypto/cipher/#NewGCM
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	//Create a nonce. Nonce should be from GCM
+	nonce := make([]byte, aesGCM.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	//Encrypt the data using aesGCM.Seal
+
+	//Since we don't want to save the nonce somewhere else in this case, we add it as a prefix to the encrypted data. The first nonce argument in Seal is the prefix.
+	ciphertext := aesGCM.Seal(nonce, nonce, plaintext, nil)
+	return fmt.Sprintf("%x", ciphertext), nil
+}
+
+func DecryptString(data string, encKey string) (string, error) {
+	key, _ := hex.DecodeString(encKey)
+	enc, _ := hex.DecodeString(data)
+
+	//Create a new Cipher Block from the key
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+
+	//Create a new GCM
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	//Get the nonce size
+	nonceSize := aesGCM.NonceSize()
+
+	//Extract the nonce from the encrypted data
+	nonce, ciphertext := enc[:nonceSize], enc[nonceSize:]
+
+	//Decrypt the data
+	plaintext, err := aesGCM.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s", plaintext), nil
 }


### PR DESCRIPTION
New feature: add encryption of passwords / private keys.
This makes it more secure to store in the database (especially passwords).

Encryption can only be added when creating a new profile.
The encryption key can be updated when updating a profile.
You will be asked to enter the key when updating a profile or when connecting to a server (duh).