### PR TITLE
fix: dont write decrypted private key to disk

### DIFF
--- a/cmd/sshman/main.go
+++ b/cmd/sshman/main.go
@@ -38,7 +38,6 @@ func main() {
 	handleErrorAndCloseGracefully(err, 1, db)
 	profileService := profiles.ProfileService{
 		DB:        db,
-		KeyPath:   cfg.PrivateKeyPath,
 		MaskInput: cfg.MaskInput,
 	}
 

--- a/cmd/sshman/main.go
+++ b/cmd/sshman/main.go
@@ -23,7 +23,7 @@ func main() {
 		Name:        "sshman",
 		Description: "SSH connection management tool.",
 		Author:      "@mikeunge",
-		Version:     "1.1.3",
+		Version:     "1.1.4",
 		Github:      "https://github.com/mikeunge/sshman",
 	}
 

--- a/config/sshman.json
+++ b/config/sshman.json
@@ -1,6 +1,5 @@
 {
   "databasepath": "~/.local/share/sshman/sshman.db",
   "logpath": "~/.local/share/sshman/sshman.log",
-  "privateKeyPath": "~/.local/share/sshman/keys/",
   "maskInput": true
 }

--- a/internal/profiles/profiles.go
+++ b/internal/profiles/profiles.go
@@ -3,10 +3,8 @@ package profiles
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -502,14 +500,9 @@ func (s *ProfileService) connectToSSH(profile *database.SSHProfile) error {
 	server := ssh.SSHServer{User: profile.User, Host: profile.Host, SecureConnection: false}
 
 	if profile.AuthType == database.AuthTypePrivateKey {
-		tmpPath := filepath.Join(s.KeyPath, fmt.Sprintf("%d.pem", rand.Int()))
-		if err := ssh.CreatePrivateKey(tmpPath, profile.PrivateKey); err != nil {
+		if err := server.ConnectSSHServerWithPrivateKey(profile.PrivateKey); err != nil {
 			return err
 		}
-		if err := server.ConnectSSHServerWithPrivateKey(tmpPath); err != nil {
-			return err
-		}
-		defer helpers.RemovePath(tmpPath)
 	} else {
 		if err := server.ConnectSSHServerWithPassword(profile.Password); err != nil {
 			return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,24 +10,21 @@ import (
 )
 
 const (
-	defaultDatabasePath   = "~/.local/share/sshman/sshman.db"
-	defaultLoggingPath    = "~/.local/share/sshman/sshman.log"
-	defaultPrivateKeyPath = "~/.local/share/sshman/keys/"
-	defaultMaskInput      = true
+	defaultDatabasePath = "~/.local/share/sshman/sshman.db"
+	defaultLoggingPath  = "~/.local/share/sshman/sshman.log"
+	defaultMaskInput    = true
 )
 
 type Config struct {
-	DatabasePath   string `json:"databasepath"`
-	LoggingPath    string `json:"logpath"`
-	PrivateKeyPath string `json:"privateKeyPath"`
-	MaskInput      bool   `json:"maskInput"`
+	DatabasePath string `json:"databasepath"`
+	LoggingPath  string `json:"logpath"`
+	MaskInput    bool   `json:"maskInput"`
 }
 
 // Paths to validate
 var PathsToValidate = []string{
 	"DatabasePath",
 	"LoggingPath",
-	"PrivateKeyPath",
 }
 
 func Parse(path string) (Config, error) {
@@ -90,10 +87,9 @@ func (c *Config) validatePaths(objectNames []string, createIfNotExist bool) erro
 
 func defaultConfig() Config {
 	config := Config{
-		DatabasePath:   defaultDatabasePath,
-		LoggingPath:    defaultLoggingPath,
-		PrivateKeyPath: defaultPrivateKeyPath,
-		MaskInput:      defaultMaskInput,
+		DatabasePath: defaultDatabasePath,
+		LoggingPath:  defaultLoggingPath,
+		MaskInput:    defaultMaskInput,
 	}
 	config.sanitizeConfigPaths()
 	config.validatePaths(PathsToValidate, true)
@@ -103,5 +99,4 @@ func defaultConfig() Config {
 func (c *Config) sanitizeConfigPaths() {
 	c.DatabasePath = helpers.SanitizePath(c.DatabasePath)
 	c.LoggingPath = helpers.SanitizePath(c.LoggingPath)
-	c.PrivateKeyPath = helpers.SanitizePath(c.PrivateKeyPath)
 }

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -4,6 +4,7 @@ import (
 	"github.com/mikeunge/sshman/pkg/helpers"
 
 	"github.com/melbahja/goph"
+	cryptSSH "golang.org/x/crypto/ssh"
 )
 
 type SSHServer struct {
@@ -31,31 +32,32 @@ func (s SSHServer) generateSSHClient(auth goph.Auth) (*goph.Client, error) {
 
 // ConnectSSHServerWithPrivateKey()
 //
-// @Param privateKeyFilePath Path to the SSH RSA private key
-// @Param password           (optional) Password for authentication
-// @Param config             SSH server configuration
+// @param privateKeyFilePath Path to the SSH RSA private key
+// @param config             SSH server configuration
 //
-// @Return error
-func (s *SSHServer) ConnectSSHServerWithPrivateKey(privateKeyFilePath string) error {
-	auth, err := goph.Key(privateKeyFilePath, "")
+// @return error
+func (s *SSHServer) ConnectSSHServerWithPrivateKey(privateKey []byte) error {
+	signer, err := cryptSSH.ParsePrivateKey(privateKey)
 	if err != nil {
 		return err
 	}
 
+	auth := goph.Auth{cryptSSH.PublicKeys(signer)}
 	client, err := s.generateSSHClient(auth)
 	if err != nil {
 		return err
 	}
+
 	s.Client = client
 	return nil
 }
 
 // ConnectSSHServerWithPassword()
 //
-// @Param password  Password for authentication
-// @Param config    SSH server configuration
+// @param password  Password for authentication
+// @param config    SSH server configuration
 //
-// @Return error
+// @return error
 func (s *SSHServer) ConnectSSHServerWithPassword(password string) error {
 	auth := goph.Password(password)
 	client, err := s.generateSSHClient(auth)
@@ -68,10 +70,10 @@ func (s *SSHServer) ConnectSSHServerWithPassword(password string) error {
 
 // CreatePrivateKey()
 //
-// @Param path  Path for the private key
-// @Param data  Binary data of the private key
+// @param path  Path for the private key
+// @param data  Binary data of the private key
 //
-// @Return error
+// @return error
 func CreatePrivateKey(path string, data []byte) error {
 	if err := helpers.CreatePathIfNotExist(path); err != nil {
 		return err


### PR DESCRIPTION
This PR fixes a problem with how we connect to a server with the usage of a private key.

The private keys (as well as the passwords) are stored encrypted in the database, but when you connect to a server we need to encrypt the key. BUT the used ssh library only accepts a path to a private key file, so we created a temp file with the key (in plain text). Now, a attacker (if he has full access to your machine) can now check directly the folder used for the keys or scan your system for .pem keys.

There where some solutions on how to mitigate the risk, eg. not using .pem extension or changing the folder where the keys are written to, but this is just fighting the symptoms.

So, I checked the source on how I can make this more secure and I saw that I can create a custom "signer" via the ssh package which then gets consumed by the used library. This way we don't leak anything onto the disk and mitigate the problem right at its core.