### PR TITLE
fix: profile not decrypted on export

### DIFF
--- a/cmd/sshman/main.go
+++ b/cmd/sshman/main.go
@@ -23,7 +23,7 @@ func main() {
 		Name:        "sshman",
 		Description: "SSH connection management tool.",
 		Author:      "@mikeunge",
-		Version:     "1.2.1",
+		Version:     "1.2.2",
 		Github:      "https://github.com/mikeunge/sshman",
 	}
 

--- a/internal/profiles/decryptProfile.go
+++ b/internal/profiles/decryptProfile.go
@@ -10,8 +10,8 @@ import (
 )
 
 func decryptProfiles(profiles []database.SSHProfile, maskInput bool, maxTries int) error {
-	for _, profile := range profiles {
-		if err := decryptProfile(&profile, maskInput, maxTries); err != nil {
+	for i := 0; i < len(profiles); i++ {
+		if err := decryptProfile(&profiles[i], maskInput, maxTries); err != nil {
 			return err
 		}
 	}
@@ -21,7 +21,6 @@ func decryptProfiles(profiles []database.SSHProfile, maskInput bool, maxTries in
 func decryptProfile(profile *database.SSHProfile, maskInput bool, maxTries int) error {
 	var err error
 
-	fmt.Print(maxTries)
 	currentTry := 0
 	if profile.Encrypted {
 		for currentTry < maxTries {


### PR DESCRIPTION
For some reason, the profile gets decrypted and also overwritten in the pointer, but for some reason this didn't catch on for the export. As I checked the code I identified a potential issue in the `decryptProfiles` function, which is just a helper for unwrapping/handling multiple profiles at once. After changing the loop from a range to a "normal" loop, the changes worked. 