### PR TITLE
refactor: encrypt profiles by default

### DIFF
--- a/cmd/sshman/main.go
+++ b/cmd/sshman/main.go
@@ -23,7 +23,7 @@ func main() {
 		Name:        "sshman",
 		Description: "SSH connection management tool.",
 		Author:      "@mikeunge",
-		Version:     "1.3.1",
+		Version:     "1.3.2",
 		Github:      "https://github.com/mikeunge/sshman",
 	}
 
@@ -50,7 +50,7 @@ func main() {
 		DecryptionRetries: cfg.DecryptionRetries,
 	}
 
-	nonValidCommands := []string{"encrypt", "id", "alias"}
+	nonValidCommands := []string{"no-encrypt", "id", "alias"}
 	command, err := determineNextStep(args, argsFound, nonValidCommands)
 	switch command {
 	case "list":
@@ -69,7 +69,11 @@ func main() {
 		err = profileService.ExportProfile(additionalArg)
 		break
 	case "new":
-		err = profileService.NewProfile(*argsFound["encrypt"])
+		encrypt := true
+		if *argsFound["no-encryption"] {
+			encrypt = false
+		}
+		err = profileService.NewProfile(encrypt)
 		break
 	case "update":
 		additionalArg := getAdditionalArg(args, argsFound)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -27,7 +27,7 @@ func (app *App) New() (map[string]interface{}, map[string]*bool, error) {
 
 	args["connect"], argsFound["connect"] = parser.Flag("-c", "--connect", &argparser.Options{Required: false, Help: "Connect to a server with profile."})
 	args["new"], argsFound["new"] = parser.Flag("-n", "--new", &argparser.Options{Required: false, Help: "Create a new SSH profile."})
-	args["encrypt"], argsFound["encrypt"] = parser.Flag("", "--encrypt", &argparser.Options{Required: false, Help: "Encrypt the password/private key."})
+	args["no-encryption"], argsFound["no-encryption"] = parser.Flag("", "--no-encrypt", &argparser.Options{Required: false, Help: "Don't encrypt the profile."})
 	args["update"], argsFound["update"] = parser.Flag("-u", "--update", &argparser.Options{Required: false, Help: "Update an SSH profile."})
 	args["delete"], argsFound["delete"] = parser.Flag("-d", "--delete", &argparser.Options{Required: false, Help: "Delete SSH profiles."})
 	args["export"], argsFound["export"] = parser.Flag("-e", "--export", &argparser.Options{Required: false, Help: "Export profiles (for eg. sharing)."})


### PR DESCRIPTION
This PR changes the encryption behavior. 
Now a new profile always gets encrypted, you actively need to op-out if you want to store the profile "plain".

Fixes: #27 